### PR TITLE
fix(plugin): use './' instead of '.' for marketplace source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "kube-dc",
-      "source": ".",
+      "source": "./",
       "description": "Kube-DC skills for Kubernetes-native data center management — 11 workflow skills covering the full platform lifecycle.",
       "version": "1.0.0",
       "author": {


### PR DESCRIPTION
## Summary

- Fix marketplace schema validation error when installing via `claude plugin marketplace add`
- Change `"source": "."` to `"source": "./"` in `.claude-plugin/marketplace.json`

## Problem

Running `claude plugin marketplace add kube-dc/kube-dc-public` fails with:

```
Failed to parse marketplace file: Invalid schema: plugins.0.source: Invalid input
```

Claude Code's marketplace schema accepts relative paths starting with `./` (e.g., `"./plugins/my-plugin"`) but rejects a bare `"."`. The fix is a one-character change: `"."` → `"./"`.

## Verified

Tested locally — after this change, both commands succeed:

```bash
claude plugin marketplace add kube-dc/kube-dc-public  # ✔
claude plugin install kube-dc                          # ✔
```